### PR TITLE
[ENG-46657] fix: handle python-hcl2 jsonencode reconstruction breaking JSON parse

### DIFF
--- a/src/akamai/converter_rules_engine.py
+++ b/src/akamai/converter_rules_engine.py
@@ -962,7 +962,8 @@ def behavior_rewrite_request(options, name):
         behaviors.append(azion_behavior)
     elif option_behavior == "REMOVE":
         match_value = replace_variables(options.get('match', ''))
-        escaped_match = match_value.replace('/', r'\/').replace('.', r'\.')
+        # match arrives with raw '/' and '.', so double-escape for HCL (\\/ -> \/ in the regex).
+        escaped_match = match_value.replace('/', r'\\/').replace('.', r'\\.')
         regex_value = f"^(.*){escaped_match}(.*)$"
         captured_array = sanitize_name(name).upper()[:10]
         captured_array = re.sub(r"\d+", "", captured_array) # Remove all numeric characters

--- a/src/akamai/converter_rules_engine.py
+++ b/src/akamai/converter_rules_engine.py
@@ -983,8 +983,11 @@ def behavior_rewrite_request(options, name):
         azion_behavior = {
             "name": "rewrite_request",
             "enabled": True,
+            # Azion requires the Rewrite Request target to start with '/', ${uri}
+            # or ${request_uri}. The captured groups rebuild the path with the
+            # matched segment removed; prefix '/' so it is a valid absolute path.
             "target": {
-                "target": f"\"%%{{{captured_array}[1]}}%%{{{captured_array}[2]}}\""
+                "target": f"\"/%%{{{captured_array}[1]}}%%{{{captured_array}[2]}}\""
             },
             "phase": "request",
             "akamai_behavior": "rewriteUrl_PREPEND"

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,22 @@
 import argparse
+import io
 import logging
+import re
 import hcl2
 import json
 from writer import write_terraform_file
 from akamai.akamai import akamai_converter
 from typing import Optional, List, Dict, Any
+
+# python-hcl2 (7.3.x) does not evaluate jsonencode(); it reconstructs the
+# expression as a string. Large numeric literals in scientific notation (e.g.
+# certificate serialNumbers like `3.12e+36`) are emitted as ${...} interpolations,
+# which triggers a greedy quote-unescaping bug that corrupts heredoc-derived
+# content downstream. Quoting these numbers before hcl2.load prevents the trigger
+# entirely (deterministic), leaving clean_and_parse_json's repair as a fallback.
+_SCIENTIFIC_NOTATION_ATTR = re.compile(
+    r'(?m)^(\s*[\w.-]+\s*=\s*)(\d+\.\d+[eE][+-]?\d+)(\s*(?:#.*)?)$'
+)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -22,7 +34,14 @@ def read_terraform_file(filepath: str) -> dict:
     try:
         with open(filepath, "r", encoding="utf-8") as file:
             logging.info(f"Reading file: {filepath}")
-            return hcl2.load(file)
+            content = file.read()
+            # Neutralize scientific-notation numeric literals before parsing so
+            # python-hcl2 does not turn them into ${...} interpolations (see note
+            # on _SCIENTIFIC_NOTATION_ATTR above).
+            content, count = _SCIENTIFIC_NOTATION_ATTR.subn(r'\1"\2"\3', content)
+            if count:
+                logging.info(f"Quoted {count} scientific-notation numeric literal(s) before parsing.")
+            return hcl2.load(io.StringIO(content))
     except FileNotFoundError as e:
         logging.error(f"File not found: {filepath}")
         raise e

--- a/src/utils.py
+++ b/src/utils.py
@@ -330,8 +330,8 @@ def clean_and_parse_json(json_string: str) -> Optional[Any]:
             try:
                 # If that fails, try to evaluate it as a Python literal
                 return ast.literal_eval(json_string)
-            except (ValueError, SyntaxError):
-                pass
+            except (ValueError, SyntaxError) as e:
+                logging.debug(f"ast.literal_eval fallback failed: {e}")
         
         # Try to parse as a plain object
         try:

--- a/src/utils.py
+++ b/src/utils.py
@@ -207,10 +207,70 @@ def compact_and_sanitize(name: str, max_length: int = 90) -> str:
         compacted = compacted[:-1]
     return compacted
 
+def repair_hcl2_jsonencode(content: str) -> str:
+    """
+    Repairs the JSON-ish string produced by python-hcl2 (7.3.x) when it
+    reconstructs an *unevaluated* `jsonencode({...})` expression.
+
+    python-hcl2 does not evaluate `jsonencode()`; it rebuilds the expression as
+    a string, and that reconstruction has two quirks that yield invalid JSON:
+
+      1. Large numeric literals (e.g. certificate serial numbers exported in
+         scientific notation such as `3.12e+36`) are emitted as `${3.12e+36}`
+         interpolations instead of plain values.
+      2. Its interpolation handling uses a greedy regex that un-escapes the
+         double quotes inside string values located *after* such a `${...}`,
+         corrupting heredoc-derived content (e.g. `result="true"` where it
+         should have stayed `result=\\"true\\"`).
+
+    This step unwraps the numeric interpolations and re-escapes the stray
+    content quotes so the result can be parsed with json.loads.
+
+    :param content: The unwrapped content of a `${jsonencode(...)}` expression.
+    :return: A repaired string suitable for json.loads.
+    """
+    # 1) Unwrap numeric interpolations: ${3.12e+36} -> 3.12e+36
+    content = re.sub(r'\$\{(\d+\.\d+[eE][+-]?\d+)\}', r'\1', content)
+
+    # 2) Re-escape double quotes that appear inside string values. A quote only
+    #    closes a string when the next non-space char is a JSON structural token
+    #    (',' ':' '}' ']'); otherwise it is content and must be escaped.
+    out = []
+    in_string = False
+    i, n = 0, len(content)
+    while i < n:
+        char = content[i]
+        if not in_string:
+            out.append(char)
+            if char == '"':
+                in_string = True
+        else:
+            if char == '\\':
+                # Preserve existing escape sequences verbatim.
+                out.append(char)
+                if i + 1 < n:
+                    out.append(content[i + 1])
+                    i += 2
+                    continue
+            elif char == '"':
+                j = i + 1
+                while j < n and content[j] in ' \t\r\n':
+                    j += 1
+                if j >= n or content[j] in ',:}]':
+                    out.append(char)
+                    in_string = False
+                else:
+                    out.append('\\"')
+            else:
+                out.append(char)
+        i += 1
+    return ''.join(out)
+
+
 def clean_and_parse_json(json_string: str) -> Optional[Any]:
     """
     Clean and parse a JSON or HCL string.
-    
+
     :param json_string: String containing the JSON or HCL.
     :return: Parsed object or None if parsing fails.
     """
@@ -230,7 +290,15 @@ def clean_and_parse_json(json_string: str) -> Optional[Any]:
         if json_string.startswith('${jsonencode(') and json_string.endswith(')}'):
             # Extract content between jsonencode( and the last )
             json_string = json_string[len('${jsonencode('):-2]
-            
+
+            # Initial step: repair python-hcl2's jsonencode reconstruction
+            # (numeric ${...} interpolations + greedily un-escaped content
+            # quotes) before attempting to parse.
+            try:
+                return json.loads(repair_hcl2_jsonencode(json_string))
+            except json.JSONDecodeError:
+                logging.debug("Repaired jsonencode content still not parseable, trying fallbacks.")
+
             # Replace single quotes with double quotes, but only if they're not within a string
             in_string = False
             escaped = False
@@ -262,7 +330,7 @@ def clean_and_parse_json(json_string: str) -> Optional[Any]:
             try:
                 # If that fails, try to evaluate it as a Python literal
                 return ast.literal_eval(json_string)
-            except ValueError:
+            except (ValueError, SyntaxError):
                 pass
         
         # Try to parse as a plain object


### PR DESCRIPTION
## Summary

This PR fixes three independent issues that prevented converting and applying a real Akamai property (heavily using `jsonencode`, heredocs, and `rewriteUrl`). Each layer was uncovered after fixing the previous one, and the final result was verified end-to-end: `terraform validate` passes and a live `terraform apply` against Azion succeeds.

---

## Fix 1 — `jsonencode` reconstruction breaking JSON parse (crash)

**Symptom:** conversion aborted with an uncaught `SyntaxError`.

**Root cause:** `python-hcl2` (7.3.x) does not evaluate `jsonencode()`; it reconstructs the expression as a string. Large numbers in scientific notation (e.g. certificate `serialNumber` like `3.12e+36`) are emitted as `${...}` interpolations, and its greedy interpolation regex then un-escapes the double quotes inside heredoc-derived string values, producing invalid JSON. `clean_and_parse_json` fell through to `ast.literal_eval`, whose `SyntaxError` was not caught, aborting the whole run.

**Fix:**
- `main.py`: quote scientific-notation numeric literals **before** `hcl2.load` (deterministic prevention of the `${...}` trigger).
- `utils.py`: add `repair_hcl2_jsonencode()` as an initial step in `clean_and_parse_json` (unwrap numeric `${...}` + re-escape stray content quotes), and catch `SyntaxError` from `ast.literal_eval`.
- `utils.py`: log the `ast.literal_eval` fallback failure at debug level instead of a bare `pass` (review feedback — makes the fallback-chain intent explicit; the final failure is still logged and returns `None`).

## Fix 2 — Invalid HCL escape sequence in `rewriteUrl` REMOVE regex

**Symptom:** `terraform` rejected the output with `Invalid escape sequence` (`\/`).

**Root cause:** the REMOVE branch of `behavior_rewrite_request` built the capture regex from a raw `match` using single-backslash escapes (`\/`, `\.`), which are invalid in HCL double-quoted strings.

**Fix:** double-escape (`\\/`, `\\.`) so HCL parses `\\/` → `\/` for the regex engine, matching the convention already used by the REPLACE branch and the criteria path builders. Scope kept surgical — the setVariable/capture path (which receives already-escaped input) is intentionally left untouched to avoid triple-escaping.

## Fix 3 — `rewriteUrl` REMOVE `rewrite_request` target rejected by Azion

**Symptom:** `apply` failed with `400 Bad Request`: *the argument for "Rewrite Request" should start with /, ${uri} or ${request_uri}*.

**Root cause:** the REMOVE branch built the target as `"%%{CAP[1]}%%{CAP[2]}"`, which starts with `%%{`; Azion requires it to start with `/`, `${uri}` or `${request_uri}`. This branch never worked end-to-end.

**Fix:** prefix `/` so the reconstructed path is a valid absolute path. Change confined to the REMOVE branch; REWRITE/REPLACE/PREPEND/forwardRewrite targets are untouched.

---

## Testing

- `terraform validate` (azion provider v1.41.0): **Success**.
- Live `terraform apply` against Azion: all resources created without errors.
- Regression checks for `clean_and_parse_json` (plain JSON, normal `jsonencode`, heredoc with quotes) pass.

## Notes (out of scope)

- The converter emits v1-style resource names (`azion_edge_application_*`); the provider must be pinned to `~> 1.0` (v2.x renamed them by dropping the `edge_` prefix).