### PR TITLE
[ENG-46478] fix: run cloudlet forward-rewrite rule last so set_origin precedes it

### DIFF
--- a/src/akamai/converter_rules_engine.py
+++ b/src/akamai/converter_rules_engine.py
@@ -34,6 +34,13 @@ CONDITIONAL_MAP = {
 }
 BEHAVIOR_CACHE_PHASE = ["NO_STORE", "NO_CACHE"]
 
+# Forward-rewrite must be the LAST request-phase rule: it rewrites the path from
+# the header set by the proxy function, and only works once set_origin (which
+# reads the origin header) has already run. A very high order guarantees it sorts
+# after every set_origin/cloudletsOrigin rule (orders increment by 10, so there
+# is huge headroom).
+FORWARD_REWRITE_ORDER = 9_999_999
+
 
 # Create order factory
 def create_order_factory(multiplier: int=10) -> int:
@@ -1040,8 +1047,8 @@ def process_forward_rewrite(context,
                                     depends_on)
 
     if len(resource) > 0:
-        if resource[0]['order'] < 100:
-            resource[0]['order'] = 100
+        if resource[0]['order'] < FORWARD_REWRITE_ORDER:
+            resource[0]['order'] = FORWARD_REWRITE_ORDER
     return resource
 
 def process_behaviors(


### PR DESCRIPTION
## Problem

Cloudlet forwards with `pathAndQS` (e.g. `/web-stories` → `/webstories` on `contentdeliverycmsless...`) returned **404**: the request was not being routed/rewritten correctly.

## Root cause

A cloudlet forward is implemented as three rules driven by headers the proxy edge function sets on match:
- the **proxy function** sets `x-az-forward-rewrite-origin` and `x-az-forward-rewrite-uri`;
- a **set_origin** rule reads `x-az-forward-rewrite-origin` and selects the origin;
- a **rewrite_request** rule reads `x-az-forward-rewrite-uri` and rewrites the path.

Azion requires `set_origin` to run **before** the rewrite; otherwise the rewritten path is applied to the wrong (default) origin and the request 404s.

`process_forward_rewrite` floored the rewrite order at `100`, but `set_origin` (cloudletsOrigin) rules receive much higher orders — so the rewrite was ordered **before** them (set_origin ended up last → 404). Because the rewrite rule is generic, this affected **every** forward with `pathAndQS`, not just one path.

## Fix

Raise the forward-rewrite order to a very high value (`FORWARD_REWRITE_ORDER`) so it sorts **after all set_origin rules** and runs last. The `depends_on` chain, which is derived from `order`, re-links automatically.

## Verification

- Reordering confirmed: all forward `set_origin` rules now precede all forward-rewrite rules.
- Diff limited to the 3 forward-rewrite rules relocating to the end + their `depends_on` re-link — no other rule changed.
- `terraform validate`: Success.
