### PR TITLE
chore: harden CI for OSSF Scorecard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,9 @@
 name: Pylint
 
-on: [push]
+on: [push, pull_request]
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -9,9 +12,11 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
## What

Security hardening to raise the OpenSSF Scorecard (currently **5.1**).

### `.github/workflows/pylint.yml`
- Pin `actions/checkout` → `@11bd71901…` (v4.2.2) and `actions/setup-python` → `@a26af69b…` (v5.6.0), full SHA + version comment — **Pinned-Dependencies** / zizmor `unpinned-uses`
- Add top-level `permissions: contents: read` — **Token-Permissions** / `excessive-permissions`
- Add `persist-credentials: false` on checkout — zizmor `artipacked`
- Add `pull_request` trigger so the check can back a required-status-check rule

### `.github/dependabot.yml`
- Add `github-actions` ecosystem (keeps the pinned SHAs patched)
- Add 7-day `cooldown` on both ecosystems — zizmor `dependabot-cooldown`

## Not included
- **Branch protection / Code-Review**: governance change, deferred to an admin.
- `Maintained` / `Contributors`: resolve from ongoing activity, not config.

Score updates on the next central OSSF scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)