### PR TITLE
[ENG-46828] fix: support Akamai regularExpression criterion

### DIFF
--- a/src/akamai/converter_rules_engine.py
+++ b/src/akamai/converter_rules_engine.py
@@ -597,6 +597,8 @@ def process_criteria(
             elif 'variableExpression' in options:
                 values = options.get("variableExpression", ['*'])
                 values = [values]
+            elif 'regex' in options:
+                values = [options.get("regex", "")]
             else:
                 values = [options.get("value", "")]
 

--- a/src/akamai/mapping.py
+++ b/src/akamai/mapping.py
@@ -7,7 +7,9 @@ from .utils import (
     format_filename_pattern,
     format_header_name,
     get_http_header_varname,
-    format_varitens_pattern
+    format_varitens_pattern,
+    format_regularexpression_pattern,
+    map_variable
 )
 
 # Mapping for Akamai to Azion behavior/criteria conversions
@@ -42,6 +44,15 @@ MAPPING = {
             "azion_condition": "$${uri}", 
             "azion_operator": lambda options: "matches" if is_positive_operator(options.get("matchOperator")) else "does_not_match",
             "input_value": format_path_pattern
+        },
+        "regularExpression": {
+            # Akamai matches an arbitrary variable (matchString, usually {{builtin.AK_PATH}} -> $${uri})
+            # against a raw regex (options.regex). There is no positive/negative operator; it is a plain match.
+            # format_regularexpression_pattern double-escapes the raw regex (\/, \\.) so Terraform's
+            # HCL parser does not consume the backslashes, matching the glob-derived criteria style.
+            "azion_condition": lambda options: map_variable(options.get("matchString", "{{builtin.AK_PATH}}")),
+            "azion_operator": "matches",
+            "input_value": format_regularexpression_pattern
         },
         "filename": {
             "azion_condition": "$${request_uri}", 

--- a/src/akamai/utils.py
+++ b/src/akamai/utils.py
@@ -449,6 +449,31 @@ def format_path_pattern(values: List[str]) -> str:
     joined = "|".join(escape_and_convert(v) for v in values)
     return rf"^({joined})$"
 
+def format_regularexpression_pattern(values: List[str]) -> str:
+    """
+    Prepares a raw Akamai `regularExpression` regex (options.regex) for embedding in
+    the generated Terraform. The value is written verbatim, so backslashes must be
+    doubled (otherwise Terraform's HCL parser consumes them as escape sequences) and
+    unescaped forward slashes are rendered as \\/ to match the double-escaped style
+    of the glob-derived path/fileExtension criteria. The pattern stays functionally
+    identical to the Akamai source.
+
+    Args:
+        values (List[str]): Single-element list holding the raw regex.
+
+    Returns:
+        str: HCL-safe, double-escaped regex pattern.
+    """
+    if not values:
+        return "*"
+    regex = values[0]
+    # Double existing backslashes so sequences like \. or \d survive HCL parsing.
+    regex = regex.replace("\\", "\\\\")
+    # Escape forward slashes that are not already escaped: / -> \\/
+    # (function replacement so re.sub does not re-process the backslashes).
+    regex = re.sub(r"(?<!\\)/", lambda _m: "\\\\/", regex)
+    return regex
+
 def format_filename_pattern(values: List[str]) -> str:
     """
     Formats a list of uri path patterns into a double-escaped regex pattern.


### PR DESCRIPTION
## Problem

Akamai's `regularExpression` criterion had no entry in `MAPPING["criteria"]`, so `process_criteria` logged `No mapping found for criterion: regularExpression. Skipping.` and dropped it silently.

On the `www.itau.com.br` (ion prod) property this broke the Bynder rules: the `Origin Bynder (/asset/)` rule is gated by a UUID regex (`^/media/dam/m/<uuid>/.+$`) that made it mutually exclusive with `Origin Bynder (/m/)`. Losing that gate made both rules match every `/media/dam/m/*` image, so the later rule won (last-wins) and rewrote non-UUID assets to `/asset/…`, which does not exist on the Bynder origin → **404** (e.g. the `ITAU_LOGO_LARANJA_114X114.png` logo).

## Fix

| File | Change |
|------|--------|
| `converter_rules_engine.py` | `process_criteria` extracts the pattern from `options.regex` |
| `mapping.py` | New `regularExpression` criteria mapping (condition via `map_variable` of `matchString`, operator `matches`, value via helper) |
| `utils.py` | New `format_regularexpression_pattern`: HCL-safe double-escaping (`\/`, `\\.`) so Terraform does not consume the backslashes, matching the glob-derived criteria style |
